### PR TITLE
fix: Fixed a bug that prevented adding in the initial.

### DIFF
--- a/options.html
+++ b/options.html
@@ -26,6 +26,9 @@
                 <option selected>CreditCard</option>
                 <option>Name</option>
                 <option>Address</option>
+                <option>TelNumber</option>
+                <option>EmailAddress</option>
+                <option>Affiliation</option>
                 <option>etc</option>
               </select>
             </div>

--- a/options.js
+++ b/options.js
@@ -1,7 +1,7 @@
 $(function(){
   let credentialInfo; // クレデンシャル情報を保持する配列
-  const tags = ["CreditCard", "Name", "Address", "etc"]; // タグの種類を保持する配列
-  const tagColors = ["primary", "secondary", "success", "light"] // タグの色を保持する配列
+  const tags = ["CreditCard", "Name", "Address", "TelNumber", "EmailAddress", "Affiliation", "etc"]; // タグの種類を保持する配列
+  const tagColors = ["primary", "secondary", "success", "info", "warning", "dark", "light"] // タグの色を保持する配列
   const maxLengthComment = 50; // 入力できるコメントの文字数
   const maxLengthData = 1000; // storageに保存できるデータ数
 
@@ -9,6 +9,9 @@ $(function(){
   chrome.storage.local.get(["Info"], function (value) {
     // グローバル変数にデータを格納して，HTML上に表示
     credentialInfo = value.Info;
+    if(credentialInfo == undefined){
+      credentialInfo = [];
+    }
     printCredentialTable(credentialInfo);
 
     // デバッグ


### PR DESCRIPTION
- 内容
  - 初期時点でデータを追加できないバグの修正
  - tagの種類追加
- 詳細
  - 初期時点でデータを追加できないバグの修正
    - chrome.storage.localに「Info」キーのデータが存在しない場合，getすると"undefined"が返ってくるので，それ以降のコードにてプロパティが定義されていないとエラーが出た
    - chrome.storage.localから「Info」キーのデータをgetした時に"undefined"だった場合，credentialInfoに空の配列を代入するようにした
  - tagの種類追加
    - "CreditCard", "Name", "Address", "TelNumber", "EmailAddress", "Affiliation"の6つのタグを用意することに決定
    - これら6つ以外の情報には"etc"を使ってもらうことにする
- 今後やること
  - [ ] その他のバグ確認 & UI改善
  - 現状でOption画面は概ね完成